### PR TITLE
Correctly Generate the Changelog

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,4 +66,4 @@ jobs:
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,15 @@ jobs:
         env:
           WITH_V: true
           DRY_RUN: true
+      - name: Changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3.18.0
+        with:
+          skip-version-file: true
+          skip-commit: true
+          output-file: false
+          skip-tag: true
+          release-count: 1
   release:
     runs-on: ubuntu-latest
     needs: test
@@ -43,6 +52,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
+      - name: Changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3.18.0
+        with:
+          skip-version-file: true
+          skip-commit: true
+          output-file: false
+          skip-tag: true
+          release-count: 1
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,6 +40,10 @@ jobs:
           output-file: false
           skip-tag: true
           release-count: 1
+      - name: Print Changelog
+        env:
+          CHANGELOG: ${{ steps.changelog.outputs.clean_changelog }}
+        run: echo $CHANGELOG
   release:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Use an action that can correctly generate a changelog, a print it for debugging on non main branches.