### PR TITLE
Imported Types

### DIFF
--- a/pkg/fields.go
+++ b/pkg/fields.go
@@ -49,6 +49,9 @@ func typeOf(f *ast.Field) string {
 // tagsAttachedTo parses all tags attached
 // to a field in Go source code
 func tagsAttachedTo(f *ast.Field) []tag {
+	if f.Tag == nil {
+		return make([]tag, 0)
+	}
 	tags := strings.Trim(f.Tag.Value, "`")
 	remaining := tags
 	parsed := make([]tag, 0)

--- a/pkg/fields.go
+++ b/pkg/fields.go
@@ -50,7 +50,7 @@ func typeNameFrom(x ast.Expr) (string, error) {
 		return tt.Name, nil
 	case *ast.SelectorExpr:
 		pf, err := typeNameFrom(tt.X)
-		return pf + "." + tt.Sel.Name, err
+		return fmt.Sprintf("%s.%s", pf, tt.Sel.Name), err
 	}
 	return "", fmt.Errorf("cannot extract type name from type %#v", x)
 }

--- a/pkg/fields.go
+++ b/pkg/fields.go
@@ -38,11 +38,18 @@ func nameOf(f *ast.Field) (string, error) {
 
 // typeOf returns the type name associated with the field
 func typeOf(f *ast.Field) string {
-	switch tt := f.Type.(type) {
+	return typeNameFrom(f.Type)
+}
+
+// typeNameFrom returns a type name associated with the expression
+func typeNameFrom(x ast.Expr) string {
+	switch tt := x.(type) {
 	case *ast.Ident:
 		return tt.Name
+	case *ast.SelectorExpr:
+		return typeNameFrom(tt.X) + "." + tt.Sel.Name
 	}
-	log.Panicf("Cannot deal with type %#v", f.Type)
+	log.Panicf("Cannot deal with type %#v", x)
 	return ""
 }
 

--- a/pkg/fields.go
+++ b/pkg/fields.go
@@ -3,7 +3,6 @@ package redeco
 import (
 	"fmt"
 	"go/ast"
-	"log"
 	"strings"
 )
 
@@ -20,7 +19,10 @@ func fromField(f *ast.Field) (field, error) {
 	if err != nil {
 		return field{}, err
 	}
-	typ := typeOf(f)
+	typ, err := typeOf(f)
+	if err != nil {
+		return field{}, err
+	}
 	t := tagsAttachedTo(f)
 	return field{name: n, typ: typ, tags: t}, nil
 }
@@ -37,20 +39,20 @@ func nameOf(f *ast.Field) (string, error) {
 }
 
 // typeOf returns the type name associated with the field
-func typeOf(f *ast.Field) string {
+func typeOf(f *ast.Field) (string, error) {
 	return typeNameFrom(f.Type)
 }
 
 // typeNameFrom returns a type name associated with the expression
-func typeNameFrom(x ast.Expr) string {
+func typeNameFrom(x ast.Expr) (string, error) {
 	switch tt := x.(type) {
 	case *ast.Ident:
-		return tt.Name
+		return tt.Name, nil
 	case *ast.SelectorExpr:
-		return typeNameFrom(tt.X) + "." + tt.Sel.Name
+		pf, err := typeNameFrom(tt.X)
+		return pf + "." + tt.Sel.Name, err
 	}
-	log.Panicf("Cannot deal with type %#v", x)
-	return ""
+	return "", fmt.Errorf("cannot extract type name from type %#v", x)
 }
 
 // tagsAttachedTo parses all tags attached

--- a/pkg/import_test.go
+++ b/pkg/import_test.go
@@ -1,0 +1,21 @@
+package redeco
+
+import "testing"
+
+func TestCanParseSourceContainingStructsWithImportedTypes(t *testing.T) {
+	g := NewFromString(`
+	package foo
+
+	import "github.com/google/uuid"
+
+	type A struct {}
+
+	type B struct {
+		U uuid.UUID
+	}
+	`)
+	_, err := g.Generate(options{handler: "bar", target: "A"})
+	if err != nil {
+		t.Errorf("Generation failed with %s", err)
+	}
+}


### PR DESCRIPTION
Ensure that structs in the target file that contain imported types can be parsed and do not cause panics