### PR TITLE
Ensure fmt imported For All Query Parameters

### DIFF
--- a/pkg/optional_query_string_test.go
+++ b/pkg/optional_query_string_test.go
@@ -10,6 +10,7 @@ func TestOptionalStringQueryParameterExtractionWithoutConversionWhenStructHasQue
 	}
 	expect := `package foo
 
+import "fmt"
 import "net/http"
 
 func sDecoder(r *http.Request) (p, error) {

--- a/pkg/query_optional.go
+++ b/pkg/query_optional.go
@@ -9,6 +9,7 @@ import (
 // optionalQueryExtractCode generates code to extract and convert
 // a query parameter associated with the provided field & tag
 func optionalQueryExtractCode(g *generation, f field, t tag) (string, error) {
+	g.newImport(iport{path: "fmt"})
 	if strings.HasPrefix(f.typ, "int") {
 		return optionalQueryIntExtractCode(g, f, t)
 	}

--- a/pkg/query_required.go
+++ b/pkg/query_required.go
@@ -9,6 +9,7 @@ import (
 // requiredQueryExtractCode generates code to extract and convert
 // a query parameter associated with the provided field & tag
 func requiredQueryExtractCode(g *generation, f field, t tag) (string, error) {
+	g.newImport(iport{path: "fmt"})
 	if strings.HasPrefix(f.typ, "int") {
 		return requiredQueryIntExtractCode(g, f, t)
 	}

--- a/pkg/query_string_test.go
+++ b/pkg/query_string_test.go
@@ -12,6 +12,7 @@ func TestStringQueryParameterExtractionWithoutConversionWhenStructHasQueryTags(t
 	}
 	expect := `package foo
 
+import "fmt"
 import "net/http"
 
 func DDecoder(r *http.Request) (A, error) {


### PR DESCRIPTION
All query parameter extraction code uses `fmt`, so ensure it is imported in all cases